### PR TITLE
remove the import role task for network-engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # servicenow_network_tickets
 Ansible role for ServiceNow network tickets
 
+Currently supports network devices that are running on Cisco IOS.
+
 
 Makes sure to create the `device uptime` & `ios version` fields in your ServiceNow incident template.
  This is exaplained in the blog post below.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ Ansible role for ServiceNow network tickets
 Makes sure to create the `device uptime` & `ios version` fields in your ServiceNow incident template.
  This is exaplained in the blog post below.
 
-The `hostname` parameter has now also been added in the data section of the api call. Make sure to create that field in tour incident template in SNOW.
+The `hostname` parameter has now also been added in the data section of the API call. Make sure to create that field in your incident template in SNOW.
 
 https://www.thenetwork.engineer/blog/utilize-ansible-for-opening-and-closing-tickets-with-servicenow-part3

--- a/README.md
+++ b/README.md
@@ -5,4 +5,6 @@ Ansible role for ServiceNow network tickets
 Makes sure to create the `device uptime` & `ios version` fields in your ServiceNow incident template.
  This is exaplained in the blog post below.
 
+The `hostname` parameter has now also been added in the data section of the api call. Make sure to create that field in tour incident template in SNOW.
+
 https://www.thenetwork.engineer/blog/utilize-ansible-for-opening-and-closing-tickets-with-servicenow-part3

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,5 @@
 ---
 
-  - name: import network-engine role
-    import_role:
-      name: ansible-network.network-engine
-
   - name: show version
     ios_command:
       commands:


### PR DESCRIPTION
removed the import role task for network-engine, it was not needed. the role is being called by the meta/ main.yml dependencies section.

updated readme